### PR TITLE
Solve deprecation warning in Julia 0.7

### DIFF
--- a/src/fmtspec.jl
+++ b/src/fmtspec.jl
@@ -176,7 +176,7 @@ function printfmt(io::IO, fs::FormatSpec, x)
         ty == 'o' ? _pfmt_i(io, fs, ix, _Oct()) :
         _pfmt_i(io, fs, ix, _Bin())
     elseif cls == 'f'
-        fx = float(x)
+        fx = parse(Float64, x)
         if isfinite(fx)
             ty == 'f' || ty == 'F' ? _pfmt_f(io, fs, fx) :
             ty == 'e' || ty == 'E' ? _pfmt_e(io, fs, fx) :


### PR DESCRIPTION
It solves the deprecation warning "`float(x::AbstractString)` is deprecated, use `parse(Float64, x)` instead." in Julia 0.7