### PR TITLE
Handling of `AbstractIrrational`

### DIFF
--- a/src/fmt.jl
+++ b/src/fmt.jl
@@ -29,7 +29,7 @@ default_spec!(::Type{T}, ::Type{K}) where {T,K} =
     (DEFAULT_FORMATTERS[T] = DEFAULT_FORMATTERS[K]; nothing)
 
 # seed it with some basic default formatters
-for (t, c) in [(Integer,'d'), (AbstractFloat,'f'), (AbstractChar,'c'), (AbstractString,'s'), (AbstractIrrational,'v')]
+for (t, c) in [(Integer,'d'), (AbstractFloat,'f'), (AbstractChar,'c'), (AbstractString,'s'), (Number, 'v')]
     default_spec!(t, c)
 end
 
@@ -67,6 +67,7 @@ default_spec(::Type{<:AbstractFloat})  = DEFAULT_FORMATTERS[AbstractFloat]
 default_spec(::Type{<:AbstractString}) = DEFAULT_FORMATTERS[AbstractString]
 default_spec(::Type{<:AbstractChar})   = DEFAULT_FORMATTERS[AbstractChar]
 default_spec(::Type{<:AbstractIrrational})   = DEFAULT_FORMATTERS[AbstractIrrational]
+default_spec(::Type{<:Number})   = DEFAULT_FORMATTERS[Number]
 
 default_spec(::Type{T}) where {T} =
     get(DEFAULT_FORMATTERS, T) do

--- a/src/fmt.jl
+++ b/src/fmt.jl
@@ -29,7 +29,7 @@ default_spec!(::Type{T}, ::Type{K}) where {T,K} =
     (DEFAULT_FORMATTERS[T] = DEFAULT_FORMATTERS[K]; nothing)
 
 # seed it with some basic default formatters
-for (t, c) in [(Integer,'d'), (AbstractFloat,'f'), (AbstractChar,'c'), (AbstractString,'s')]
+for (t, c) in [(Integer,'d'), (AbstractFloat,'f'), (AbstractChar,'c'), (AbstractString,'s'), (AbstractIrrational,'v')]
     default_spec!(t, c)
 end
 
@@ -66,6 +66,7 @@ default_spec(::Type{<:Integer})        = DEFAULT_FORMATTERS[Integer]
 default_spec(::Type{<:AbstractFloat})  = DEFAULT_FORMATTERS[AbstractFloat]
 default_spec(::Type{<:AbstractString}) = DEFAULT_FORMATTERS[AbstractString]
 default_spec(::Type{<:AbstractChar})   = DEFAULT_FORMATTERS[AbstractChar]
+default_spec(::Type{<:AbstractIrrational})   = DEFAULT_FORMATTERS[AbstractIrrational]
 
 default_spec(::Type{T}) where {T} =
     get(DEFAULT_FORMATTERS, T) do
@@ -176,7 +177,7 @@ function fmt end
 # TODO: do more caching to optimize repeated calls
 
 # creates a new FormatSpec by overriding the defaults and passes it to pyfmt
-# note: adding kwargs is only appropriate for one-off formatting.  
+# note: adding kwargs is only appropriate for one-off formatting.
 #       normally it will be much faster to change the fmt_default formatting as needed
 function fmt(x; kwargs...)
     fspec = fmt_default(x)

--- a/src/fmt.jl
+++ b/src/fmt.jl
@@ -31,8 +31,10 @@ default_spec!(::Type{T}, ::Type{K}) where {T,K} =
 # seed it with some basic default formatters
 ComplexInteger = Complex{T} where T<:Integer
 ComplexFloat = Complex{T} where T<:AbstractFloat
+ComplexRational = Complex{T} where T<:Rational
 for (t, c) in [(Integer,'d'), (AbstractFloat,'f'), (AbstractChar,'c'), (AbstractString,'s'),
-    (ComplexInteger, 'd'), (ComplexFloat, 'f'), (Number,'S'), (AbstractIrrational,'S')]
+    (ComplexInteger,'d'), (ComplexFloat,'f'), (Number,'S'), (AbstractIrrational,'S'),
+    (Rational,'S'), (ComplexRational,'S')]
     default_spec!(t, c)
 end
 
@@ -73,6 +75,8 @@ default_spec(::Type{<:AbstractIrrational}) = DEFAULT_FORMATTERS[AbstractIrration
 default_spec(::Type{<:Number})             = DEFAULT_FORMATTERS[Number]
 default_spec(::ComplexInteger)             = DEFAULT_FORMATTERS[ComplexInteger]
 default_spec(::ComplexFloat)               = DEFAULT_FORMATTERS[ComplexFloat]
+default_spec(::Rational)                   = DEFAULT_FORMATTERS[Rational]
+default_spec(::ComplexRational)            = DEFAULT_FORMATTERS[ComplexRational]
 
 default_spec(::Type{T}) where {T} =
     get(DEFAULT_FORMATTERS, T) do

--- a/src/fmt.jl
+++ b/src/fmt.jl
@@ -32,7 +32,7 @@ default_spec!(::Type{T}, ::Type{K}) where {T,K} =
 ComplexInteger = Complex{T} where T<:Integer
 ComplexFloat = Complex{T} where T<:AbstractFloat
 for (t, c) in [(Integer,'d'), (AbstractFloat,'f'), (AbstractChar,'c'), (AbstractString,'s'),
-    (ComplexInteger, 'd'), (ComplexFloat, 'f'), (Number,'s'), (AbstractIrrational,'s')]
+    (ComplexInteger, 'd'), (ComplexFloat, 'f'), (Number,'S'), (AbstractIrrational,'S')]
     default_spec!(t, c)
 end
 
@@ -65,14 +65,14 @@ end
 # methods to get the current default objects
 # note: if you want to set a default for an abstract type (i.e. AbstractFloat)
 # you'll need to extend this method like here:
-default_spec(::Type{<:Integer})        = DEFAULT_FORMATTERS[Integer]
-default_spec(::Type{<:AbstractFloat})  = DEFAULT_FORMATTERS[AbstractFloat]
-default_spec(::Type{<:AbstractString}) = DEFAULT_FORMATTERS[AbstractString]
-default_spec(::Type{<:AbstractChar})   = DEFAULT_FORMATTERS[AbstractChar]
+default_spec(::Type{<:Integer})            = DEFAULT_FORMATTERS[Integer]
+default_spec(::Type{<:AbstractFloat})      = DEFAULT_FORMATTERS[AbstractFloat]
+default_spec(::Type{<:AbstractString})     = DEFAULT_FORMATTERS[AbstractString]
+default_spec(::Type{<:AbstractChar})       = DEFAULT_FORMATTERS[AbstractChar]
 default_spec(::Type{<:AbstractIrrational}) = DEFAULT_FORMATTERS[AbstractIrrational]
-default_spec(::Type{<:Number})         = DEFAULT_FORMATTERS[Number]
-default_spec(::ComplexInteger)     = DEFAULT_FORMATTERS[ComplexInteger]
-default_spec(::ComplexFloat)  = DEFAULT_FORMATTERS[ComplexFloat]
+default_spec(::Type{<:Number})             = DEFAULT_FORMATTERS[Number]
+default_spec(::ComplexInteger)             = DEFAULT_FORMATTERS[ComplexInteger]
+default_spec(::ComplexFloat)               = DEFAULT_FORMATTERS[ComplexFloat]
 
 default_spec(::Type{T}) where {T} =
     get(DEFAULT_FORMATTERS, T) do
@@ -208,5 +208,5 @@ function fmt(x, syms::Symbol...; kwargs...)
     fmt(x; d...)
 end
 
-fmt_default!(AbstractIrrational, 's', :right)
-fmt_default!(Number, 's', :right)
+#fmt_default!(AbstractIrrational, 's', :right)
+#fmt_default!(Number, 's', :right)

--- a/src/fmtcore.jl
+++ b/src/fmtcore.jl
@@ -262,3 +262,40 @@ function _pfmt_specialf(out::IO, fs::FormatSpec, x::AbstractFloat)
     end
 end
 
+function _pfmt_Number_f(out::IO, fs::FormatSpec, x::Number, _pf::Function)
+    fsi = FormatSpec(fs, width = -1)
+    f = x::AbstractFloat->begin
+        io = IOBuffer()
+        _pf(io, fsi, x)
+        String(take!(io))
+    end
+    s = _fmt_Number(x, f)
+    _pfmt_s(out, fs, s)
+end
+
+function _pfmt_Number_i(out::IO, fs::FormatSpec, x::Number, op::Op, _pf::Function) where {Op}
+    fsi = FormatSpec(fs, width = -1)
+    f = x::Integer->begin
+        io = IOBuffer()
+        _pf(io, fsi, x, op)
+        String(take!(io))
+    end
+    s = _fmt_Number(x, f)
+    _pfmt_s(out, fs, s)
+end
+
+function _pfmt_i(out::IO, fs::FormatSpec, x::Number, op::Op) where {Op}
+    _pfmt_Number_i(out, fs, x, op, _pfmt_i)
+end
+
+function _pfmt_f(out::IO, fs::FormatSpec, x::Number)
+    _pfmt_Number_f(out, fs, x, _pfmt_f)
+end
+
+function _pfmt_e(out::IO, fs::FormatSpec, x::Number)
+    _pfmt_Number_f(out, fs, x, _pfmt_e)
+end
+
+function _fmt_Number(x::Complex, f::Function)
+    s = f(real(x)) * (imag(x) >= 0 ? " + " : " - ") * f(abs(imag(x))) * "im"
+end

--- a/src/fmtcore.jl
+++ b/src/fmtcore.jl
@@ -1,4 +1,5 @@
 # core formatting functions
+export fmt_Number
 
 ### auxiliary functions
 
@@ -269,7 +270,7 @@ function _pfmt_Number_f(out::IO, fs::FormatSpec, x::Number, _pf::Function)
         _pf(io, fsi, x)
         String(take!(io))
     end
-    s = _fmt_Number(x, f)
+    s = fmt_Number(x, f)
     _pfmt_s(out, fs, s)
 end
 
@@ -280,7 +281,7 @@ function _pfmt_Number_i(out::IO, fs::FormatSpec, x::Number, op::Op, _pf::Functio
         _pf(io, fsi, x, op)
         String(take!(io))
     end
-    s = _fmt_Number(x, f)
+    s = fmt_Number(x, f)
     _pfmt_s(out, fs, s)
 end
 
@@ -296,6 +297,6 @@ function _pfmt_e(out::IO, fs::FormatSpec, x::Number)
     _pfmt_Number_f(out, fs, x, _pfmt_e)
 end
 
-function _fmt_Number(x::Complex, f::Function)
+function fmt_Number(x::Complex, f::Function)
     s = f(real(x)) * (imag(x) >= 0 ? " + " : " - ") * f(abs(imag(x))) * "im"
 end

--- a/src/fmtspec.jl
+++ b/src/fmtspec.jl
@@ -9,7 +9,7 @@
 #  width ::= <integer>
 #  prec  ::= <integer>
 #  type  ::= 'b' | 'c' | 'd' | 'e' | 'E' | 'f' | 'F' | 'g' | 'G' |
-#            'n' | 'o' | 'x' | 'X' | 's' | 'v'
+#            'n' | 'o' | 'x' | 'X' | 's' | 'S'
 #
 # Please refer to http://docs.python.org/2/library/string.html#formatspec
 # for more details
@@ -17,18 +17,18 @@
 
 ## FormatSpec type
 
-const _numtypchars = Set(['b', 'd', 'e', 'E', 'f', 'F', 'g', 'G', 'n', 'o', 'x', 'X', 'v'])
+const _numtypchars = Set(['b', 'd', 'e', 'E', 'f', 'F', 'g', 'G', 'n', 'o', 'x', 'X', 'S'])
 
 _tycls(c::AbstractChar) =
     (c == 'd' || c == 'n' || c == 'b' || c == 'o' || c == 'x') ? 'i' :
     (c == 'e' || c == 'f' || c == 'g') ? 'f' :
     (c == 'c') ? 'c' :
     (c == 's') ? 's' :
-    (c == 'v') ? 'v' :
+    (c == 'S') ? 'S' :
     error("Invalid type char $(c)")
 
 struct FormatSpec
-    cls::Char    # category: 'i' | 'f' | 'c' | 's'
+    cls::Char    # category: 'i' | 'f' | 'c' | 's' | 'S'
     typ::Char
     fill::Char
     align::Char
@@ -85,7 +85,7 @@ end
 
 ## parse FormatSpec from a string
 
-const _spec_regex = r"^(.?[<>])?([ +-])?(#)?(\d+)?(,)?(.\d+)?([bcdeEfFgGnosxXv])?$"
+const _spec_regex = r"^(.?[<>])?([ +-])?(#)?(\d+)?(,)?(.\d+)?([bcdeEfFgGnosxXS])?$"
 
 function FormatSpec(s::AbstractString)
     # default spec
@@ -196,7 +196,7 @@ function printfmt(io::IO, fs::FormatSpec, x)
         else
             _pfmt_specialf(io, fs, fx)
         end
-    elseif cls == 's' || cls == 'v'
+    elseif cls == 's' || cls == 'S'
         _pfmt_s(io, fs, _srepr(x))
     else # cls == 'c'
         _pfmt_s(io, fs, Char(x))

--- a/src/fmtspec.jl
+++ b/src/fmtspec.jl
@@ -173,14 +173,22 @@ function printfmt(io::IO, fs::FormatSpec, x)
     cls = fs.cls
     ty = fs.typ
     if cls == 'i'
-        ix = Integer(x)
+        ix = x
+        try
+            ix = Integer(x)
+        catch
+        end
         ty == 'd' || ty == 'n' ? _pfmt_i(io, fs, ix, _Dec()) :
         ty == 'x' ? _pfmt_i(io, fs, ix, _Hex()) :
         ty == 'X' ? _pfmt_i(io, fs, ix, _HEX()) :
         ty == 'o' ? _pfmt_i(io, fs, ix, _Oct()) :
         _pfmt_i(io, fs, ix, _Bin())
     elseif cls == 'f'
-        fx = float(x)
+        fx = x
+        try
+            fx = float(x)
+        catch
+        end
         if isfinite(fx)
             ty == 'f' || ty == 'F' ? _pfmt_f(io, fs, fx) :
             ty == 'e' || ty == 'E' ? _pfmt_e(io, fs, fx) :

--- a/src/fmtspec.jl
+++ b/src/fmtspec.jl
@@ -165,6 +165,9 @@ _srepr(x) = repr(x)
 _srepr(x::AbstractString) = x
 _srepr(x::AbstractChar) = string(x)
 _srepr(x::Enum) = string(x)
+@static if VERSION < v"1.2.0-DEV"
+    _srepr(x::Irrational{sym}) where {sym} = string(sym)
+end
 
 function printfmt(io::IO, fs::FormatSpec, x)
     cls = fs.cls

--- a/src/fmtspec.jl
+++ b/src/fmtspec.jl
@@ -9,7 +9,7 @@
 #  width ::= <integer>
 #  prec  ::= <integer>
 #  type  ::= 'b' | 'c' | 'd' | 'e' | 'E' | 'f' | 'F' | 'g' | 'G' |
-#            'n' | 'o' | 'x' | 'X' | 's'
+#            'n' | 'o' | 'x' | 'X' | 's' | 'v'
 #
 # Please refer to http://docs.python.org/2/library/string.html#formatspec
 # for more details
@@ -17,13 +17,14 @@
 
 ## FormatSpec type
 
-const _numtypchars = Set(['b', 'd', 'e', 'E', 'f', 'F', 'g', 'G', 'n', 'o', 'x', 'X'])
+const _numtypchars = Set(['b', 'd', 'e', 'E', 'f', 'F', 'g', 'G', 'n', 'o', 'x', 'X', 'v'])
 
 _tycls(c::AbstractChar) =
     (c == 'd' || c == 'n' || c == 'b' || c == 'o' || c == 'x') ? 'i' :
     (c == 'e' || c == 'f' || c == 'g') ? 'f' :
     (c == 'c') ? 'c' :
     (c == 's') ? 's' :
+    (c == 'v') ? 'v' :
     error("Invalid type char $(c)")
 
 struct FormatSpec
@@ -84,7 +85,7 @@ end
 
 ## parse FormatSpec from a string
 
-const _spec_regex = r"^(.?[<>])?([ +-])?(#)?(\d+)?(,)?(.\d+)?([bcdeEfFgGnosxX])?$"
+const _spec_regex = r"^(.?[<>])?([ +-])?(#)?(\d+)?(,)?(.\d+)?([bcdeEfFgGnosxXv])?$"
 
 function FormatSpec(s::AbstractString)
     # default spec
@@ -184,7 +185,7 @@ function printfmt(io::IO, fs::FormatSpec, x)
         else
             _pfmt_specialf(io, fs, fx)
         end
-    elseif cls == 's'
+    elseif cls == 's' || cls == 'v'
         _pfmt_s(io, fs, _srepr(x))
     else # cls == 'c'
         _pfmt_s(io, fs, Char(x))

--- a/test/fmt.jl
+++ b/test/fmt.jl
@@ -20,10 +20,19 @@ i = 1234567
 @test fmt(i) == "1234567"
 @test fmt(i,:commas) == "1,234,567"
 
-fmt(3//4, 10) == "      3//4"
-fmt(2 - 3im, 10) == "   2 - 3im"
-fmt(pi - 3im, 15, 2) == "  3.14 - 3.00im"
-fmt(1//2 + 6//2 * im, 15) == " 1//2 + 3//1*im"
+@test fmt(2 - 3im, 10) == "   2 - 3im"
+@test fmt(pi - 3im, 15, 2) == "  3.14 - 3.00im"
+
+@test fmt(3//4, 10) == "      3//4"
+@test fmt(1//2 + 6//2 * im, 15) == " 1//2 + 3//1*im"
+
+fmt_default!(Rational, 'f', prec = 2)
+fmt_default!(Format.ComplexRational, 'f', prec = 2)
+
+@test fmt(3//4, 10, 2) == "      0.75"
+@test fmt(3//4, 10, 1) == "       0.8"
+@test fmt(1//2 + 6//2 * im, 23) == "  0.500000 + 3.000000im"
+@test fmt(1//2 + 6//2 * im, 15, 2) == "  0.50 + 3.00im"
 
 fmt_default!(Int, :commas, width = 12)
 @test fmt(i) == "   1,234,567"
@@ -49,4 +58,3 @@ v = pi
 
 v = MathConstants.eulergamma
 @test fmt(v, 10, 2) == "         γ"
-@test pyfmt("10.2f", v) == "      0.58"

--- a/test/fmt.jl
+++ b/test/fmt.jl
@@ -44,6 +44,9 @@ fmt_default!(UInt32, UInt16, width=20)
 @test fmt(0xfffff) == "           1,048,575"
 
 v = pi
-
 @test fmt(v) == "π"
 @test fmt(v; width=10) == "         π"
+
+v = MathConstants.eulergamma
+@test fmt(v, 10, 2) == "         γ"
+@test pyfmt("10.2f", v) == "      0.58"

--- a/test/fmt.jl
+++ b/test/fmt.jl
@@ -41,3 +41,7 @@ fmt_default!(UInt16, 'd', :commas)
 fmt_default!(UInt32, UInt16, width=20)
 @test fmt(0xfffff) == "           1,048,575"
 
+v = pi
+
+@test fmt(v) == "π"
+@test fmt(v; width=10) == "         π"

--- a/test/fmt.jl
+++ b/test/fmt.jl
@@ -20,8 +20,10 @@ i = 1234567
 @test fmt(i) == "1234567"
 @test fmt(i,:commas) == "1,234,567"
 
-@test_throws ErrorException fmt_default(Real)
-@test_throws ErrorException fmt_default(Complex)
+fmt(3//4, 10) == "      3//4"
+fmt(2 - 3im, 10) == "   2 - 3im"
+fmt(pi - 3im, 15, 2) == "  3.14 - 3.00im"
+fmt(1//2 + 6//2 * im, 15) == " 1//2 + 3//1*im"
 
 fmt_default!(Int, :commas, width = 12)
 @test fmt(i) == "   1,234,567"

--- a/test/fmtspec.jl
+++ b/test/fmtspec.jl
@@ -234,3 +234,9 @@ end
     @test pyfmt("*>5f", Inf) == "**Inf"
     @test pyfmt("⋆>5f", Inf) == "⋆⋆Inf"
 end
+
+@testset "Format variable (v) for Irrationals" begin
+    @test pyfmt("10v", pi) == "         π"
+    @test pyfmt("3v", MathConstants.eulergamma) == "  γ"
+    @test pyfmt("<3v", MathConstants.e) == "ℯ  "
+end

--- a/test/fmtspec.jl
+++ b/test/fmtspec.jl
@@ -235,8 +235,9 @@ end
     @test pyfmt("⋆>5f", Inf) == "⋆⋆Inf"
 end
 
-@testset "Format variable (v) for Irrationals" begin
-    @test pyfmt("10v", pi) == "         π"
-    @test pyfmt("3v", MathConstants.eulergamma) == "  γ"
-    @test pyfmt("<3v", MathConstants.e) == "ℯ  "
+@testset "Format Symbols (S) for Irrationals" begin
+    @test pyfmt("10S", pi) == "         π"
+    @test pyfmt("3S", MathConstants.eulergamma) == "  γ"
+    @test pyfmt("10.2f", MathConstants.eulergamma) == "      0.58"
+    @test pyfmt("<3S", MathConstants.e) == "ℯ  "
 end

--- a/test/fmtspec.jl
+++ b/test/fmtspec.jl
@@ -241,3 +241,9 @@ end
     @test pyfmt("10.2f", MathConstants.eulergamma) == "      0.58"
     @test pyfmt("<3S", MathConstants.e) == "ℯ  "
 end
+
+@testset "Format Symbols (S) for Irrationals" begin
+    pyfmt("10s", 3//4) == "3//4      "
+    pyfmt("10S", 3//4) == "      3//4"
+    pyfmt("10.1f", 3//4) == "       0.8"
+end


### PR DESCRIPTION
Currently `Format.jl` fails to handle the printout of `Irrationals` such as `pi`.

This can be circumvented by defining a new `DEFAULTFORMATTER` for `AbstractIrrational`.
I wondered, what a good standard print format might be
- numeric representation, (`'f'`)
- symbolic representation, which would be a right-aligned string

In this PR I propose to introduce a new type and class character 'v' for "variable" which is per default right-aligned, so that the result of `pyfmt(FormatSpec("2v"), pi)` (EDIT: as well as `fmt(pi,2)`) is `" π"`

Together with the `StringLiterals.jl` package this would make it possible to write `f"\%(pi, 10)"` to print a right-aligned symbol.

I understand that the introduction of a new character type breaks with the standard Python format, so I am a bit unsure, whether this is a good idea, or how it could be done better. So I'd be happy to receive some feedback here.

EDIT: two more comments ...
- I want to give some more reasoning for my idea:
At the REPL `print(pi)` results in `π`, whereas print(1pi) results in `3.141592653589793`. This behaviour would then be identical.
- The 'v' type would be also quite useful for any other symbolic printout, e.g.:
```
using Sympy
@vars a  # (a,)
default_spec!(Sym, 'v')
fmt(1.234a,10)
"   1.234*a"
```