### PR TITLE
Correct format gG precision handling

### DIFF
--- a/src/fmtcore.jl
+++ b/src/fmtcore.jl
@@ -332,12 +332,14 @@ function _pfmt_e(out::IO, fs::FormatSpec, x::AbstractFloat)
 end
 
 function _pfmt_g(out::IO, fs::FormatSpec, x::AbstractFloat)
-    # number decomposition
-    ax = abs(x)
-    if 1.0e-4 <= ax < 1.0e6
-        _pfmt_f(out, fs, x)
+    # Branch according to the exponent
+    expnt = floor(Int, log10(abs(x)) )
+    if -4 <= expnt < fs.prec
+        newprec = fs.prec - expnt - 1
+        _pfmt_f(out, FormatSpec(fs ;prec=newprec), x)
     else
-        _pfmt_e(out, fs, x)
+        newprec = fs.prec - 1
+        _pfmt_e(out, FormatSpec(fs ;prec=newprec), x)
     end
 end
 


### PR DESCRIPTION
The current implementation does not adhere to the Python documentation and forward the precision directly to `__pfmt_f()` and `__pfmt_e()`, this means the only time it is correct is for numbers in the range of `0.1 <= x < 1.0`. 
Additionally the Python spec makes sure the printed number will never have trailing zeros by switching to scientific notation when number of integer digits exceeds precision. The current implementation simply hard code it to `x < 1E6`.

The exact wording is as follows
> The precise rules are as follows: suppose that the result formatted with presentation type `'e'` and precision `p-1` would have exponent exp. Then, if `m <= exp < p`, where `m` is -4 for `floats` and -6 for `Decimals`, the number is formatted with presentation type `'f'` and precision `p-1-exp`.

Since I am new here I don't know if taking log directly will affect performance, and if floating point imprecision will make it 1 less than the actual exponent, but it currently has the correct behavior.

This will resolve https://github.com/JuliaString/Format.jl/issues/88